### PR TITLE
Resolução de novos Casos de teste (4)

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fileformat/MrDLibImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/MrDLibImporterTest.java
@@ -1,10 +1,15 @@
 package org.jabref.logic.importer.fileformat;
 
 import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.Buffer;
+import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.core.util.BufferRecycler;
+import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.util.FileType;
 import org.jabref.model.entry.BibEntry;
@@ -13,8 +18,10 @@ import org.jabref.model.entry.FieldName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MrDLibImporterTest {
 
@@ -86,5 +93,21 @@ public class MrDLibImporterTest {
         List<BibEntry> resultList = parserResult.getDatabase().getEntries();
 
         assertSame(0, resultList.size());
+    }
+
+    @Test
+    public void testGetParserResult(){
+        importer.parserResult = new ParserResult(Collections.emptyList());
+        assertEquals(importer.getParserResult().isEmpty(), importer.parserResult.isEmpty());
+    }
+
+    @Test
+    public void testFalseIsRecognizedFormat() throws IOException {
+        assertFalse(importer.isRecognizedFormat(new BufferedReader(new FileReader(".gitignore"))));
+    }
+
+    @Test
+    public void testTrueIsRecognizedFormat() throws IOException {
+        assertTrue(importer.isRecognizedFormat(new BufferedReader(new FileReader("teste.xml"))));
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
@@ -1,6 +1,11 @@
 package org.jabref.logic.importer.fileformat;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -14,7 +19,7 @@ import org.jabref.model.entry.BibEntry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class PdfContentImporterTest {
@@ -43,6 +48,44 @@ public class PdfContentImporterTest {
         Path file = Paths.get(PdfContentImporter.class.getResource("/pdfs/encrypted.pdf").toURI());
         List<BibEntry> result = importer.importDatabase(file, StandardCharsets.UTF_8).getDatabase().getEntries();
         assertEquals(Collections.emptyList(), result);
+    }
+
+    @Test
+    public void testStringImportDatabase() throws IOException {
+        assertThrows(UnsupportedOperationException.class,()->{
+            importer.importDatabase("Julia");
+        });
+    }
+
+    @Test
+    public void testStringNullImportDatabase() throws IOException {
+        assertThrows(NullPointerException.class,()->{
+            importer.importDatabase((String) null);
+        });
+    }
+
+    @Test
+    public void testBRImportDatabase() throws IOException {
+        assertThrows(NullPointerException.class,()->{
+            importer.importDatabase(new BufferedReader(new FileReader(".gitignore")));
+        });
+    }
+
+    @Test
+    public void testBRNullImportDatabase() throws IOException {
+        assertThrows(NullPointerException.class,()->{
+            importer.importDatabase(new BufferedReader(new FileReader((File) null)));
+        });
+    }
+
+    @Test
+    public void testBR2ImportDatabase() throws IOException {
+        assertFalse(importer.importDatabase(Paths.get(".gitignore"), null).isEmpty());
+    }
+
+    @Test
+    public void testBR2InvalidImportDatabase() throws IOException {
+        assertTrue(importer.importDatabase(Paths.get("julia/.gitignore"), null).isInvalid());
     }
 
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
@@ -65,8 +65,8 @@ public class PdfContentImporterTest {
     }
 
     @Test
-    public void testBRImportDatabase() throws IOException {
-        assertThrows(NullPointerException.class,()->{
+    public void testBRImportDatabase() {
+        assertThrows(UnsupportedOperationException.class,()->{
             importer.importDatabase(new BufferedReader(new FileReader(".gitignore")));
         });
     }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfXmpImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfXmpImporterTest.java
@@ -1,5 +1,8 @@
 package org.jabref.logic.importer.fileformat;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -20,8 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class PdfXmpImporterTest {
@@ -89,5 +91,43 @@ public class PdfXmpImporterTest {
     @Test
     public void testGetCommandLineId() {
         assertEquals("xmp", importer.getId());
+    }
+
+    @Test
+    public void testStringImportDatabase() throws IOException {
+        assertThrows(UnsupportedOperationException.class,()->{
+            importer.importDatabase("Julia");
+        });
+    }
+
+    @Test
+    public void testStringNullImportDatabase() throws IOException {
+        assertThrows(NullPointerException.class,()->{
+            importer.importDatabase((String) null);
+        });
+    }
+
+    @Test
+    public void testBRImportDatabase() {
+        assertThrows(UnsupportedOperationException.class,()->{
+            importer.importDatabase(new BufferedReader(new FileReader(".gitignore")));
+        });
+    }
+
+    @Test
+    public void testBRNullImportDatabase() throws IOException {
+        assertThrows(NullPointerException.class,()->{
+            importer.importDatabase(new BufferedReader(new FileReader((File) null)));
+        });
+    }
+
+    @Test
+    public void testBR2ImportDatabase() throws IOException {
+        assertFalse(importer.importDatabase(Paths.get(".gitignore"), null).isEmpty());
+    }
+
+    @Test
+    public void testBR2InvalidImportDatabase() throws IOException {
+        assertTrue(importer.importDatabase(Paths.get("julia/.gitignore"), null).isInvalid());
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/RepecNepImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/RepecNepImporterTest.java
@@ -78,4 +78,9 @@ public class RepecNepImporterTest {
         assertEquals("Imports a New Economics Papers-Message from the REPEC-NEP Service.",
                 testImporter.getDescription());
     }
+
+    /*
+     * - O metodo importDatabase não especifica a excessao do try-catch
+     * - As outras propriedades são privadas e, portanto, nao ha como testa-las
+     */
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/SilverPlatterImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/SilverPlatterImporterTest.java
@@ -63,4 +63,8 @@ public class SilverPlatterImporterTest {
         assertEquals("Imports a SilverPlatter exported file.", testImporter.getDescription());
     }
 
+    /*
+     * O codigo apresenta aprox. 98,2 de cobertura. O restante eh inalcancavel
+     */
+
 }


### PR DESCRIPTION
Muitos arquivos de teste não precisaram de testes adicionais, devido à alta cobertura ou ao forte encapsulamento das propriedades das classes.